### PR TITLE
Fix for traceback when building database

### DIFF
--- a/cwe/database.py
+++ b/cwe/database.py
@@ -94,7 +94,7 @@ class Database(object):
                         cwe_id: str = row["CWE-ID"]
                         # Update the category index
                         if cwe_id not in category_index[category]:
-                            category_index[category].append()
+                            category_index[category].append(cwe_id)
                         #  Insert the cwe into it's respective category
                         db_dict[cwe_id] = row
 


### PR DESCRIPTION
The current implementation of `_build_database` raises a traceback because it is calling `append()` with no parameters.

This change adds cwe_id as the expected parameter to append. Afterwards, the database build proceeds successfully.